### PR TITLE
GridObject Refs Fixed

### DIFF
--- a/Assets/Scripts/Building.cs
+++ b/Assets/Scripts/Building.cs
@@ -28,16 +28,14 @@ public class Building : MonoBehaviour
 
         PayConstructionCosts();
         
-        if (resourceData.tileUnder == null)
+        if (Terrainsystem == null)
         {
             RaycastHit hit;
             Physics.Raycast(transform.position, Vector3.down, out hit);
             SetGridObject(hit.transform.gameObject.GetComponent<GridObject>());
         }
 
-        
-
-        resourceData.tileUnder.GetOwningGridSystem().ToggleBuildMode(resourceData, true);
+        Terrainsystem.owningGridObject.GetOwningGridSystem().ToggleBuildMode(resourceData, true);
 
         UpdateTotalBuildingCount(true);
         TimeSystem.AddMonthlyEvent(Impact);
@@ -97,14 +95,13 @@ public class Building : MonoBehaviour
         {
             gameObject.GetComponentInChildren<ResourceUpdatePopup>().AnimatePopup();
         }
-
     }
     
     public void PayUpkeep()
     {
         if (!resourceData.upKeepCostEnergy || Terrainsystem.Lenergy)
         {
-            if (!resourceData.upKeepCostWater || (Inventory.isFlooding || resourceData.tileUnder.terrain.Wenergy))
+            if (!resourceData.upKeepCostWater || (Inventory.isFlooding || Terrainsystem.Wenergy))
             {
                 Upkeepmet = 1;
                 Inventory.SpendFood(resourceData.upKeepCostFood);
@@ -129,19 +126,18 @@ public class Building : MonoBehaviour
 
     public GridObject GetOwningGridObject()
     {
-        return resourceData.tileUnder;
+        return Terrainsystem.owningGridObject;
     }    
 
     public void SetGridObject(GridObject gridObject)
     {
-        if (resourceData)
-            resourceData.tileUnder = gridObject;
+        if (gridObject.terrain == null)
+        {
+            gridObject.SetTerrain();
+        }
 
-        if (oldresourceData)
-            oldresourceData.tileUnder = gridObject;
-
-        if (newresourceData)
-            newresourceData.tileUnder = gridObject;
+        Terrainsystem = gridObject.terrain;
+        Terrainsystem.owningGridObject = gridObject;
     }
 
     public void Impact()

--- a/Assets/Scripts/BuildingSystem/Test.mat
+++ b/Assets/Scripts/BuildingSystem/Test.mat
@@ -66,7 +66,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 3775f04ed78a48b41810b4fb1a2d13ed, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Scripts/Grid System/GridObject.cs
+++ b/Assets/Scripts/Grid System/GridObject.cs
@@ -11,6 +11,12 @@ public class GridObject : MonoBehaviour
     private void Start()
     {
         gameObject.GetComponentInChildren<MeshRenderer>().enabled = false;
+
+        SetTerrain();
+    }
+
+    public void SetTerrain()
+    {
         // Check for the terrain type under this GridObject, and set references to it
         RaycastHit hit;
 


### PR DESCRIPTION
All GridObject refs go through Terrainsystem now, instead of through the ScriptableObject TileBase.