### PR TITLE
 Fixed nullref bug in TimeSystem event manager | 15:47 | 23.07.24

### DIFF
--- a/Assets/Scripts/Building.cs
+++ b/Assets/Scripts/Building.cs
@@ -42,14 +42,14 @@ public class Building : MonoBehaviour
             Terrainsystem.owningGridObject.GetOwningGridSystem().ToggleBuildMode(resourceData, true);
 
         UpdateTotalBuildingCount(true);
-        TimeSystem.AddMonthlyEvent(Impact, 1, true, 1);
+        TimeSystem.AddMonthlyEvent(this,Impact, 1, true, 1);
        
         if ( !resourceData.isResourceTapped )
         {
-            TimeSystem.AddMonthlyEvent(HarvestSurroundingResources, 1, true, 1);
+            TimeSystem.AddMonthlyEvent(this,HarvestSurroundingResources, 1, true, 1);
         }
 
-        TimeSystem.AddMonthlyEvent(PayUpkeep, 1, true, 1);
+        TimeSystem.AddMonthlyEvent(this,PayUpkeep, 1, true, 1);
         StartCoroutine(FindGridObject());
         
     }

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -51,8 +51,8 @@ public class LevelManager : MonoBehaviour
         Inventory.food = startingFoodAmount;
         Inventory.constructionMaterials = startingConstructionMaterialAmount;
         StartCoroutine(FindSoilHealth());
-        TimeSystem.AddMonthlyEvent(Inventory.HealthBarChange, 1, true, 3);
-        TimeSystem.AddMonthlyEvent(Terrainsystem.ResetValuesSoilGrade, 1, true, 4);
+        TimeSystem.AddMonthlyEvent(this, Inventory.HealthBarChange, 1, true, 3);
+        TimeSystem.AddMonthlyEvent(this, Terrainsystem.ResetValuesSoilGrade, 1, true, 4);
     }
 
     IEnumerator FindSoilHealth()

--- a/Assets/Scripts/Menus and UI/SeasonUI.cs
+++ b/Assets/Scripts/Menus and UI/SeasonUI.cs
@@ -17,7 +17,7 @@ public class SeasonUI : MonoBehaviour
     private void Start()
     {
         UpdateSeasonDisplay();
-        TimeSystem.AddMonthlyEvent(UpdateSeasonDisplay);
+        TimeSystem.AddMonthlyEvent(this, UpdateSeasonDisplay);
     }
 
     public void UpdateSeasonDisplay()

--- a/Assets/Scripts/TerrainSystem/Tilesystem.cs
+++ b/Assets/Scripts/TerrainSystem/Tilesystem.cs
@@ -81,7 +81,7 @@ public class Terrainsystem : MonoBehaviour
 
         tilecount++;
 
-        TimeSystem.AddMonthlyEvent(HealthBar, 1, true, 2);
+        TimeSystem.AddMonthlyEvent(this,HealthBar, 1, true, 2);
         //TimeSystem.AddMonthlyEvent(ResetValuesSoilGrade, 1, true, 2);
 
         //TimeSystem.AddMonthlyEvent(ChangeinGrade, 1, true, 2);

--- a/Assets/Scripts/WeatherSystem.cs
+++ b/Assets/Scripts/WeatherSystem.cs
@@ -32,7 +32,7 @@ public class WeatherSystem : MonoBehaviour
 
     private void Start()
     {
-        TimeSystem.AddMonthlyEvent(SetWeather, 1, true, 6);
+        TimeSystem.AddMonthlyEvent(this, SetWeather, 1, true, 6);
     }
 
     public void SetWeather()


### PR DESCRIPTION
-- Bug: When buildings were destroyed, the TimeSystem continued to attempt to run their events - even after the owning script was destroyed.

-- Fix: Added a MonoBehaviour variable to the Monthly Event delegate. Each script that adds a monthly event now has to pass itself as a reference, and the event manager checks that reference and removes all events whose owners have been destroyed.